### PR TITLE
Support ArrayObject properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.0",
         "dealnews/constraints": "^2.2.0",
-        "dealnews/repository": "^3.1"
+        "dealnews/repository": "^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.38",

--- a/src/AbstractMapper.php
+++ b/src/AbstractMapper.php
@@ -66,11 +66,11 @@ abstract class AbstractMapper implements Mapper {
      *
      * @param array $data Array of data loaded from the database
      *
-     * @suppress PhanTypeExpectedObjectOrClassName
+     * @suppress PhanTypeExpectedObjectOrClassName, PhanEmptyFQSENInClasslike
      */
     protected function setData(array $data): object {
         $class  = $this::MAPPED_CLASS;
-        $object = new $class(); // @phan-suppress-current-line PhanEmptyFQSENInClasslike
+        $object = new $class();
         foreach ($this::MAPPING as $property => $mapping) {
             $this->setValue($object, $property, $data, $mapping);
         }
@@ -113,6 +113,10 @@ abstract class AbstractMapper implements Mapper {
      * @suppress PhanUnusedProtectedMethodParameter
      */
     protected function setValue(object $object, string $property, array $data, array $mapping) {
+        if (!empty($mapping['rename']) && array_key_exists($mapping['rename'], $data)) {
+            $data[$property] = $data[$mapping['rename']];
+        }
+
         if (array_key_exists($property, $data)) {
             $value = $data[$property];
 
@@ -146,6 +150,18 @@ abstract class AbstractMapper implements Mapper {
                     $timezone = $mapping['timezone'] ?? null;
                     $format   = $mapping['format'] ?? 'Y-m-d H:i:s';
                     $value    = $mapping['class']::createFromFormat($format, $value, $timezone);
+                }
+            }
+
+            if (gettype($object->$property) === 'boolean') {
+                if (isset($mapping['bool_values'])) {
+                    $vals  = array_flip($mapping['bool_values']);
+                    $value = $vals[$value] === 'true';
+                } elseif (gettype($value) !== 'boolean') {
+                    $value = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                }
+                if ($value === null) {
+                    $value = false;
                 }
             }
 
@@ -215,6 +231,14 @@ abstract class AbstractMapper implements Mapper {
                     $e->getCode(),
                     $e->getPrevious()
                 );
+            }
+        }
+
+        if (isset($mapping['bool_values'])) {
+            if ($value === true) {
+                $value = $mapping['bool_values']['true'];
+            } else {
+                $value = $mapping['bool_values']['false'];
             }
         }
 

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -47,8 +47,6 @@ class Repository extends \DealNews\Repository\Repository {
      * Returns a new object of type $name
      *
      * @param string         $name   Mapped Object name
-     *
-     * @return object
      */
     public function new(string $name): object {
         $class_name = $this->findClass($name);
@@ -76,7 +74,10 @@ class Repository extends \DealNews\Repository\Repository {
     }
 
     /**
-     * Returns objects matching the filters
+     * Returns objects matching the filters. This method does not check
+     * the Repository storage for data. The data is returned from the Mapper.
+     * The data is stored in the Repository storage however after it is
+     * retrieved.
      *
      * @param  string $name    Mapped Object name
      * @param  array  $filters Array of filters. See \DealNews\DataMapper\AbstractMapper::find()
@@ -84,9 +85,13 @@ class Repository extends \DealNews\Repository\Repository {
      * @return boolean|array
      */
     public function find(string $name, array $filters): bool|array {
-        $mapper     = $this->getMapper($name);
+        $mapper = $this->getMapper($name);
+        $data   = $mapper->find($filters);
+        if (!empty($data)) {
+            $this->setMulti($name, $data);
+        }
 
-        return $mapper->find($filters);
+        return $data;
     }
 
     /**
@@ -146,8 +151,9 @@ class Repository extends \DealNews\Repository\Repository {
         if (isset($this->mappers[$class])) {
             $object = $this->mappers[$class]->save($object);
             if ($object) {
+                $key    = $this->mappers[$class]->getPrimaryKey();
                 $return = [
-                    $this->mappers[$class]->getPrimaryKey() => $object,
+                    $object->$key => $object,
                 ];
             }
         }

--- a/tests/AbstractMapper/SetGetValueTest.php
+++ b/tests/AbstractMapper/SetGetValueTest.php
@@ -42,6 +42,55 @@ class SetGetValueTest extends \PHPUnit\Framework\TestCase {
 
     public function encodingSetData() {
         return [
+
+            'Bool True String Yes uses Filter' => [
+                'bool',
+                [
+                    'bool' => 'Yes',
+                ],
+                [
+                ],
+                true,
+            ],
+
+            'Bool False String No uses Filter' => [
+                'bool',
+                [
+                    'bool' => 'No',
+                ],
+                [
+                ],
+                false,
+            ],
+
+            'Bool True String AYE uses bool values' => [
+                'bool',
+                [
+                    'bool' => 'AYE',
+                ],
+                [
+                    'bool_values' => [
+                        'true'  => 'AYE',
+                        'false' => 'NAY',
+                    ],
+                ],
+                true,
+            ],
+
+            'Bool False String NAY uses bool values' => [
+                'bool',
+                [
+                    'bool' => 'NAY',
+                ],
+                [
+                    'bool_values' => [
+                        'true'  => 'AYE',
+                        'false' => 'NAY',
+                    ],
+                ],
+                false,
+            ],
+
             'JSON Array' => [
                 'json_array',
                 [
@@ -128,6 +177,31 @@ class SetGetValueTest extends \PHPUnit\Framework\TestCase {
 
     public function encodingGetData() {
         return [
+
+            'Bool True String Yes' => [
+                'bool',
+                true,
+                [
+                    'bool_values' => [
+                        'true'  => 'Yes',
+                        'false' => 'No',
+                    ],
+                ],
+                'Yes',
+            ],
+
+            'Bool False String No' => [
+                'bool',
+                false,
+                [
+                    'bool_values' => [
+                        'true'  => 'Yes',
+                        'false' => 'No',
+                    ],
+                ],
+                'No',
+            ],
+
             'JSON Array' => [
                 'json_array',
                 [
@@ -188,16 +262,23 @@ class SetGetValueTest extends \PHPUnit\Framework\TestCase {
 }
 
 class SetGetValueMock {
-    public $int;
-    public $string;
-    public $bool;
-    public $float;
-    public array $json_array;
+    public int $int          = 0;
+    public string $string    = '';
+    public bool $bool        = false;
+    public float $float      = 0.0;
+    public array $json_array = [];
     public \stdClass $json_object;
-    public array $yaml;
+    public array $yaml = [];
     public \stdClass $class;
     public \DateTime $dt;
     public \DateTimeImmutable $dti;
+
+    public function __construct() {
+        $this->json_object = new \stdClass();
+        $this->class       = new \stdClass();
+        $this->dt          = new \DateTime();
+        $this->dti         = new \DateTimeImmutable();
+    }
 }
 
 class SetGetValueMapperMock extends AbstractMapper {

--- a/tests/AbstractMapperTest.php
+++ b/tests/AbstractMapperTest.php
@@ -3,27 +3,62 @@
 namespace DealNews\DataMapper\Tests;
 
 use \DealNews\DataMapper\Tests\TestClasses\Course;
+use \DealNews\DataMapper\Tests\TestClasses\Student;
+use \DealNews\DataMapper\Tests\TestClasses\Teacher;
 use \DealNews\DataMapper\Tests\TestClasses\Mapper\CourseMapper;
 
 class AbstractMapperTest extends \PHPUnit\Framework\TestCase {
+
     public function testSetData() {
         $mapper = new CourseMapper();
+
         $course = $mapper->testSetData([
             'course_id'   => 1,
             'name'        => 'Test Course',
+            'active'      => 'foo',
+            'teacher'     => [
+                'teacher_id'      => 1,
+                'name'            => 'Teacher 1',
+                'create_datetime' => '2020-01-03',
+            ],
+            'students'    => [
+                [
+                    'student_id'      => 2,
+                    'name'            => 'Student 2',
+                    'create_datetime' => '2020-01-02',
+                ]
+            ],
             'create_date' => '2020-01-01',
         ]);
 
         $this->assertEquals(1, $course->course_id);
         $this->assertEquals('Test Course', $course->name);
         $this->assertEquals('2020-01-01', $course->create_datetime);
+        $this->assertTrue($course->students[0] instanceof Student);
+
+        $this->assertEquals(
+            '{"course_id":1,"name":"Test Course","create_datetime":"2020-01-01","active":false,"students":{"0":{"student_id":2,"name":"Student 2","create_datetime":"2020-01-02"}},"teacher":{"teacher_id":1,"name":"Teacher 1","create_datetime":"2020-01-03"}}',
+            json_encode($course)
+        );
     }
 
     public function testGetData() {
-        $course              = new Course();
-        $course->course_id   = 2;
-        $course->name        = 'Test Course 2';
-        $course->create_date = '2020-01-01';
+        $student = new Student();
+        $student->student_id = 2;
+        $student->name = 'Student 2';
+        $student->create_datetime = '2020-01-02';
+
+        $teacher = new Teacher();
+        $teacher->teacher_id = 1;
+        $teacher->name = 'Teacher 1';
+        $teacher->create_datetime = '2020-01-03';
+
+        $course                  = new Course();
+        $course->course_id       = 2;
+        $course->name            = 'Test Course 2';
+        $course->create_datetime = '2020-01-01';
+        $course->teacher         = $teacher;
+        $course->students        = new \ArrayObject([$student]);
 
         $mapper = new CourseMapper();
         $data   = $mapper->testGetData($course);
@@ -32,6 +67,19 @@ class AbstractMapperTest extends \PHPUnit\Framework\TestCase {
             [
                 'course_id' => 2,
                 'name'      => 'Test Course 2',
+                'students'  => [
+                    [
+                        'student_id'      => 2,
+                        'name'            => 'Student 2',
+                        'create_datetime' => '2020-01-02',
+                    ]
+                ],
+                'teacher'   => [
+                    'teacher_id'      => 1,
+                    'name'            => 'Teacher 1',
+                    'create_datetime' => '2020-01-03',
+                ],
+                'active' => false,
             ],
             $data
         );

--- a/tests/AbstractMapperTest.php
+++ b/tests/AbstractMapperTest.php
@@ -16,7 +16,7 @@ class AbstractMapperTest extends \PHPUnit\Framework\TestCase {
 
         $this->assertEquals(1, $course->course_id);
         $this->assertEquals('Test Course', $course->name);
-        $this->assertEquals('2020-01-01', $course->create_date);
+        $this->assertEquals('2020-01-01', $course->create_datetime);
     }
 
     public function testGetData() {

--- a/tests/RepositoryTest.php
+++ b/tests/RepositoryTest.php
@@ -13,7 +13,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase {
     }
 
     public function testSaveChild() {
-        $repo = new Repository();
+        $repo = $this->getRepo();
         $repo->addMapper('CourseChild', new CourseMapper);
 
         $course       = new CourseChild();
@@ -36,7 +36,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase {
             ]
         );
 
-        $courses = $repo->get('Course', [$id]);
+        $courses = $repo->getMulti('Course', [$id]);
 
         $this->assertNotEmpty(
             $courses
@@ -57,7 +57,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase {
 
         $id = $this->save('TestDelete');
 
-        $courses = $repo->get('Course', [$id]);
+        $courses = $repo->getMulti('Course', [$id]);
 
         $this->assertNotEmpty(
             $courses
@@ -69,7 +69,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase {
             $result
         );
 
-        $courses = $repo->get('Course', [$id]);
+        $courses = $repo->getMulti('Course', [$id]);
 
         $this->assertEmpty(
             $courses
@@ -126,33 +126,33 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase {
     public function testBadNew() {
         $this->expectException('\LogicException');
         $this->expectExceptionCode('1');
-        $repo = new Repository();
+        $repo = $this->getRepo();
         $obj  = $repo->new('Foo');
     }
 
     public function testBadDelete() {
         $this->expectException('\LogicException');
         $this->expectExceptionCode('1');
-        $repo = new Repository();
+        $repo = $this->getRepo();
         $obj  = $repo->delete('Foo', 1);
     }
 
     public function testBadFind() {
         $this->expectException('\LogicException');
         $this->expectExceptionCode('1');
-        $repo = new Repository();
+        $repo = $this->getRepo();
         $obj  = $repo->find('Foo', []);
     }
 
     public function testBadClass() {
         $this->expectException('\LogicException');
         $this->expectExceptionCode('4');
-        $repo = new Repository();
+        $repo = $this->getRepo();
         $obj  = $repo->addMapper('bad', new BadMapper());
     }
 
     protected function save($name = 'Test') {
-        $repo = new Repository();
+        $repo = $this->getRepo();
         $repo->addMapper('Course', new CourseMapper);
 
         $course       = new Course();
@@ -165,7 +165,15 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase {
             $course->name
         );
 
+        $this->assertIsInt(key($repo->storage['Course']));
+
         return $course->course_id;
+    }
+
+    protected function getRepo() {
+        return new class extends Repository {
+            public array $storage = [];
+        };
     }
 }
 

--- a/tests/TestClasses/Course.php
+++ b/tests/TestClasses/Course.php
@@ -16,14 +16,25 @@ class Course {
      *
      * @var integer
      */
-    public $course_id = 0;
+    public int $course_id = 0;
 
     /**
      * A short name
      *
      * @var string
      */
-    public $name = '';
+    public string $name = '';
 
-    public $create_datetime = '';
+    public string $create_datetime = '';
+
+    public bool $active = false;
+
+    public \ArrayObject $students;
+
+    public Teacher $teacher;
+
+    public function __construct() {
+        $this->students = new \ArrayObject();
+        $this->teacher  = new Teacher();
+    }
 }

--- a/tests/TestClasses/Course.php
+++ b/tests/TestClasses/Course.php
@@ -25,5 +25,5 @@ class Course {
      */
     public $name = '';
 
-    public $create_date = '';
+    public $create_datetime = '';
 }

--- a/tests/TestClasses/Mapper/CourseMapper.php
+++ b/tests/TestClasses/Mapper/CourseMapper.php
@@ -22,6 +22,18 @@ class CourseMapper extends \DealNews\DataMapper\AbstractMapper {
                 'max' => 100,
             ],
         ],
+        'active' => [],
+        'teacher'    => [
+            'class'       => \DealNews\DataMapper\Tests\TestClasses\Teacher::class,
+            'one_to_many' => false,
+        ],
+        'students'    => [
+            'class'       => \DealNews\DataMapper\Tests\TestClasses\Student::class,
+            'one_to_many' => true,
+            'constraint'  => [
+                'type' => 'array',
+            ],
+        ],
         'create_datetime' => [
             'rename'    => 'create_date',
             'read_only' => true,

--- a/tests/TestClasses/Mapper/CourseMapper.php
+++ b/tests/TestClasses/Mapper/CourseMapper.php
@@ -22,7 +22,8 @@ class CourseMapper extends \DealNews\DataMapper\AbstractMapper {
                 'max' => 100,
             ],
         ],
-        'create_date' => [
+        'create_datetime' => [
+            'rename'    => 'create_date',
             'read_only' => true,
         ],
     ];

--- a/tests/TestClasses/Student.php
+++ b/tests/TestClasses/Student.php
@@ -3,25 +3,28 @@
 namespace DealNews\DataMapper\Tests\TestClasses;
 
 /**
- * Test Child of Course Class
+ * Test Student Class
  *
  * @author      Brian Moon <brianm@dealnews.com>
  * @copyright   1997-Present DealNews.com, Inc
  * @package     DataMapper
  */
-class CourseChild extends Course {
+class Student {
 
     /**
      * The unique id
      *
      * @var integer
      */
-    public int $course_id = 0;
+    public $student_id = 0;
 
     /**
      * A short name
      *
      * @var string
      */
-    public string $name = '';
+    public $name = '';
+
+    public $create_datetime = '';
+
 }

--- a/tests/TestClasses/Teacher.php
+++ b/tests/TestClasses/Teacher.php
@@ -3,25 +3,28 @@
 namespace DealNews\DataMapper\Tests\TestClasses;
 
 /**
- * Test Child of Course Class
+ * Test Teacher Class
  *
  * @author      Brian Moon <brianm@dealnews.com>
  * @copyright   1997-Present DealNews.com, Inc
  * @package     DataMapper
  */
-class CourseChild extends Course {
+class Teacher {
 
     /**
      * The unique id
      *
      * @var integer
      */
-    public int $course_id = 0;
+    public $teacher_id = 0;
 
     /**
      * A short name
      *
      * @var string
      */
-    public string $name = '';
+    public $name = '';
+
+    public $create_datetime = '';
+
 }


### PR DESCRIPTION
If an object has a property that an object that extends ArrayObject, and the data contains an array for that property, the code should recognize that and use ArrayObject::exchangeArray to set the value rather than trying to assign an array to an object.